### PR TITLE
Add harvester for new data center, "Rolling Deck to Repository" (R2R)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ New Features
 
   - Add `harvest` support for
     [Rolling Deck to Repository (R2R)](http://get.rvdata.us/services/cruise/)
+  - Add subcommands `-v` and `--version` to display the installed version of the
+    gem
 
 ## v3.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v3.2.0
+
+New Features
+
+  - Add `harvest` support for
+    [Rolling Deck to Repository (R2R)](http://get.rvdata.us/services/cruise/)
+
 ## v3.1.2
 
 Changes

--- a/bin/search_solr_tools
+++ b/bin/search_solr_tools
@@ -66,6 +66,7 @@ class SolrHarvestCLI < Thor
         'ices'               => SearchSolrTools::Harvesters::Ices,
         'nmi'                => SearchSolrTools::Harvesters::Nmi,
         'nodc'               => SearchSolrTools::Harvesters::Nodc,
+        'r2r'                => SearchSolrTools::Harvesters::R2R,
         'rda'                => SearchSolrTools::Harvesters::Rda,
         'usgs'               => SearchSolrTools::Harvesters::Usgs,
         'tdar'               => SearchSolrTools::Harvesters::Tdar,

--- a/bin/search_solr_tools
+++ b/bin/search_solr_tools
@@ -3,9 +3,9 @@ require 'search_solr_tools'
 require 'thor'
 
 class SolrHarvestCLI < Thor
-  map %w[--version -v] => :__print_version
+  map %w(--version -v) => :__print_version
 
-  desc "--version, -v", "print the version"
+  desc '--version, -v', 'print the version'
   def __print_version
     puts SearchSolrTools::VERSION
   end

--- a/bin/search_solr_tools
+++ b/bin/search_solr_tools
@@ -3,11 +3,17 @@ require 'search_solr_tools'
 require 'thor'
 
 class SolrHarvestCLI < Thor
+  map %w[--version -v] => :__print_version
+
+  desc "--version, -v", "print the version"
+  def __print_version
+    puts SearchSolrTools::VERSION
+  end
+
   desc 'harvest', 'Harvest from one of the ADE harvesters'
   option :data_center, type: :array, required: true
   option :environment, required: true
   option :die_on_failure, type: :boolean
-
   def harvest(die_on_failure = options[:die_on_failure] || false)
     options[:data_center].each do |target|
       puts target

--- a/lib/search_solr_tools/config/environments.yaml
+++ b/lib/search_solr_tools/config/environments.yaml
@@ -29,6 +29,7 @@
     - http://data.eol.ucar.edu/jedi/catalog/ucar.ncar.eol.project.BARROW.thredds.xml
     - http://data.eol.ucar.edu/jedi/catalog/ucar.ncar.eol.project.DBO.thredds.xml
     - http://data.eol.ucar.edu/jedi/catalog/ucar.ncar.eol.project.ITEX.thredds.xml
+  :r2r_url: http://get.rvdata.us/services/cruise/
 
 :local:
   :host: localhost

--- a/lib/search_solr_tools/harvesters/r2r.rb
+++ b/lib/search_solr_tools/harvesters/r2r.rb
@@ -1,0 +1,61 @@
+require 'nokogiri'
+require 'rest-client'
+
+require_relative 'base'
+
+module SearchSolrTools
+  module Harvesters
+    class R2R < Base
+      def initialize(env = 'development', die_on_failure = false)
+        super
+        @data_centers = Helpers::SolrFormat::DATA_CENTER_NAMES[:R2R][:long_name]
+        @translator = Helpers::IsoToSolr.new :r2r
+        @metadata_url = SolrEnvironments[@environment][:r2r_url]
+      end
+
+      def harvest_and_delete
+        puts "Running #{self.class.name} at #{@metadata_url}"
+        super(method(:harvest), %(data_centers:"#{@data_centers}"))
+      end
+
+      # rubocop: disable MethodLength
+      # rubocop: disable AbcSize
+      def harvest
+        # first fetch list of available records at http://get.rvdata.us/services/cruise/
+        # then loop through each one of those, using the root <gmi:MI_Metadata> tag
+        puts "Getting list of records from #{@data_centers}"
+        RestClient.get(@metadata_url) do |resp, _req, _result, &_block|
+          unless resp.code == 200
+            puts "Got code #{resp.code} from #{@metadata_url}, skipping R2R harvest."
+            next
+          end
+
+          doc = Nokogiri::HTML(resp.body)
+
+          urls = doc.xpath('//a').map do |node|
+            "#{@metadata_url}#{node.attr('href')}"
+          end
+
+          urls.each_slice(50) do |url_subset|
+            # each result is a nokogirii doc with root element
+            # <gmi:MI_Metadata>
+            results = url_subset.map do |url|
+              get_results(url, '//gmi:MI_Metadata').first
+            end
+
+            begin
+              translated = results.map do |e|
+                create_new_solr_add_doc_with_child(@translator.translate(e).root)
+              end
+
+              insert_solr_docs(translated)
+            rescue => e
+              puts "ERROR: #{e}"
+              raise e if @die_on_failure
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/search_solr_tools/helpers/iso_namespaces.rb
+++ b/lib/search_solr_tools/helpers/iso_namespaces.rb
@@ -7,23 +7,23 @@ module SearchSolrTools
       end
 
       ISO_NAMESPACES = {
-        'csw' => 'http://www.opengis.net/cat/csw/2.0.2',
-        'gmd' => 'http://www.isotc211.org/2005/gmd',
-        'gco' => 'http://www.isotc211.org/2005/gco',
-        'gml' => 'http://www.opengis.net/gml/3.2',
-        'gmi' => 'http://www.isotc211.org/2005/gmi',
-        'gmx' => 'http://www.isotc211.org/2005/gmx',
-        'gsr' => 'http://www.isotc211.org/2005/gsr',
-        'gss' => 'http://www.isotc211.org/2005/gss',
-        'gts' => 'http://www.isotc211.org/2005/gts',
-        'srv' => 'http://www.isotc211.org/2005/srv',
-        'xlink' => 'http://www.w3.org/1999/xlink',
-        'xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-        'oai' => 'http://www.openarchives.org/OAI/2.0/',
-        'dif' => 'http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/',
-        'atom' => 'http://www.w3.org/2005/Atom',
-        'dc' => 'http://purl.org/dc/elements/1.1/',
-        'georss' => 'http://www.georss.org/georss'
+        'atom'   => 'http://www.w3.org/2005/Atom',
+        'csw'    => 'http://www.opengis.net/cat/csw/2.0.2',
+        'dc'     => 'http://purl.org/dc/elements/1.1/',
+        'dif'    => 'http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/',
+        'gco'    => 'http://www.isotc211.org/2005/gco',
+        'georss' => 'http://www.georss.org/georss',
+        'gmd'    => 'http://www.isotc211.org/2005/gmd',
+        'gmi'    => 'http://www.isotc211.org/2005/gmi',
+        'gml'    => 'http://www.opengis.net/gml/3.2',
+        'gmx'    => 'http://www.isotc211.org/2005/gmx',
+        'gsr'    => 'http://www.isotc211.org/2005/gsr',
+        'gss'    => 'http://www.isotc211.org/2005/gss',
+        'gts'    => 'http://www.isotc211.org/2005/gts',
+        'oai'    => 'http://www.openarchives.org/OAI/2.0/',
+        'srv'    => 'http://www.isotc211.org/2005/srv',
+        'xlink'  => 'http://www.w3.org/1999/xlink',
+        'xsi'    => 'http://www.w3.org/2001/XMLSchema-instance'
       }
     end
   end

--- a/lib/search_solr_tools/helpers/r2r_format.rb
+++ b/lib/search_solr_tools/helpers/r2r_format.rb
@@ -1,0 +1,25 @@
+require_relative './iso_namespaces'
+require_relative './iso_to_solr_format'
+require_relative './solr_format'
+
+module SearchSolrTools
+  module Helpers
+    class R2RFormat < IsoToSolrFormat
+      TEMPORAL_INDEX_STRING = proc { |node| R2RFormat.temporal_index_str(node) }
+      TEMPORAL_DISPLAY_STRING = proc { |node| R2RFormat.temporal_display_str(node) }
+      TEMPORAL_DURATION = proc { |node| R2RFormat.get_temporal_duration(node) }
+      FACET_TEMPORAL_DURATION = proc { |node| R2RFormat.get_temporal_duration_facet(node) }
+
+      def self.date_range(temporal_node, _formatted = false)
+        xpath_start = './/gmd:temporalElement/gmd:EX_SpatialTemporalExtent/gmd:extent/'\
+                      'gml:TimeInstant[@gml:id="start"]/gml:timePosition'
+        xpath_end = xpath_start.gsub('start', 'end')
+
+        {
+          start: temporal_node.xpath(xpath_start).text,
+          end:   temporal_node.xpath(xpath_end).text
+        }
+      end
+    end
+  end
+end

--- a/lib/search_solr_tools/helpers/selectors.rb
+++ b/lib/search_solr_tools/helpers/selectors.rb
@@ -12,6 +12,7 @@ module SearchSolrTools
       nmi:    Selectors::NMI,
       nodc:   Selectors::NODC,
       pdc:    Selectors::PDC,
+      r2r:    Selectors::R2R,
       rda:    Selectors::RDA,
       tdar:   Selectors::TDAR,
       usgs:   Selectors::USGS

--- a/lib/search_solr_tools/helpers/solr_format.rb
+++ b/lib/search_solr_tools/helpers/solr_format.rb
@@ -9,18 +9,19 @@ module SearchSolrTools
     # rubocop:disable Metrics/ModuleLength
     module SolrFormat
       DATA_CENTER_NAMES = {
-        NSIDC: { short_name: 'NSIDC', long_name: 'National Snow and Ice Data Center' },
+        BCODMO: { short_name: 'BCO-DMO', long_name: 'Biological and Chemical Oceanography Data Management Office' },
         CISL: { short_name: 'ACADIS Gateway', long_name: 'Advanced Cooperative Arctic Data and Information Service' },
         ECHO: { short_name: 'NASA ECHO', long_name: 'NASA Earth Observing System (EOS) Clearing House (ECHO)' },
         EOL: { short_name: 'UCAR NCAR EOL', long_name: 'UCAR NCAR - Earth Observing Laboratory' },
         ICES: { short_name: 'ICES', long_name: 'International Council for the Exploration of the Sea' },
         NMI: { short_name: 'Met.no', long_name: 'Norwegian Meteorological Institute' },
         NODC: { short_name: 'NOAA NODC', long_name: 'NOAA National Oceanographic Data Center' },
+        NSIDC: { short_name: 'NSIDC', long_name: 'National Snow and Ice Data Center' },
+        PDC: { short_name: 'PDC', long_name: 'Polar Data Catalogue' },
+        R2R: { short_name: 'R2R', long_name: 'Rolling Deck to Repository' },
         RDA: { short_name: 'UCAR NCAR RDA', long_name: 'UCAR NCAR Research Data Archive' },
-        USGS: { short_name: 'USGS ScienceBase', long_name: 'U.S. Geological Survey ScienceBase' },
-        BCODMO: { short_name: 'BCO-DMO', long_name: 'Biological and Chemical Oceanography Data Management Office' },
         TDAR: { short_name: 'tDAR', long_name: 'tDAR: The Digital Archaeological Record' },
-        PDC: { short_name: 'PDC', long_name: 'Polar Data Catalogue' }
+        USGS: { short_name: 'USGS ScienceBase', long_name: 'U.S. Geological Survey ScienceBase' }
       }
 
       NOT_SPECIFIED = 'Not specified'

--- a/lib/search_solr_tools/selectors/r2r.rb
+++ b/lib/search_solr_tools/selectors/r2r.rb
@@ -1,0 +1,113 @@
+require 'search_solr_tools'
+
+module SearchSolrTools
+  module Selectors
+    # The hash contains keys that should map to the fields in the solr schema,
+    # the keys are called selectors and are in charge of selecting the nodes
+    # from the ISO document, applying the default value if none of the xpaths
+    # resolved to a value and formatting the field.  xpaths and multivalue are
+    # required, default_value, format, and reduce are optional.
+    #
+    # reduce takes the formatted result of multiple nodes and produces a single
+    #   result. This is for fields that are not multivalued, but their value
+    #   should consider information from all the nodes (for example, storing
+    #   only the maximum duration from multiple temporal coverage fields, taking
+    #   the sum of multiple spatial areas)
+    R2R = {
+      authoritative_id: {
+        xpaths: ['.//gmd:fileIdentifier/gco:CharacterString'],
+        multivalue: false
+      },
+      title: {
+        xpaths: ['.//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gmx:Anchor'],
+        multivalue: false
+      },
+      summary: {
+        xpaths: ['.//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString'],
+        multivalue: false
+      },
+      data_centers: {
+        xpaths: [''],
+        default_values: [Helpers::SolrFormat::DATA_CENTER_NAMES[:R2R][:long_name]],
+        multivalue: false
+      },
+      authors: {
+        xpaths: [".//gmd:CI_ResponsibleParty[./gmd:role/gmd:CI_RoleCode[@codeListValue='contributor']]/gmd:individualName/gmx:Anchor"],
+        multivalue: true
+      },
+      keywords: {
+        xpaths: ['.//gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString',
+                 './/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gmx:Anchor'],
+        multivalue: true
+      },
+      last_revision_date: {
+        xpaths: ['.//gmd:dateStamp/gco:Date', './/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:DateTime'],
+        default_values: [Helpers::SolrFormat.date_str(DateTime.now)], # formats the date into ISO8601 as in http://lucene.apache.org/solr/4_4_0/solr-core/org/apache/solr/schema/DateField.html
+        multivalue: false,
+        format: Helpers::SolrFormat::DATE
+      },
+      dataset_url: {
+        xpaths: ['.//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href'],
+        multivalue: false,
+        format: Helpers::IsoToSolrFormat::DATASET_URL
+      },
+      spatial_coverages: {
+        xpaths: ['.//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox'],
+        multivalue: true,
+        format: Helpers::IsoToSolrFormat::SPATIAL_DISPLAY
+      },
+      spatial: {
+        xpaths: ['.//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox'],
+        multivalue: true,
+        format: Helpers::IsoToSolrFormat::SPATIAL_INDEX
+      },
+      spatial_area: {
+        xpaths: ['.//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox'],
+        multivalue: false,
+        reduce: Helpers::IsoToSolrFormat::MAX_SPATIAL_AREA,
+        format: Helpers::IsoToSolrFormat::SPATIAL_AREA
+      },
+      temporal_coverages: {
+        xpaths: ['.//gmd:EX_Extent[@id="temporalExtent"]'],
+        multivalue: false,
+        format: Helpers::R2RFormat::TEMPORAL_DISPLAY_STRING
+      },
+      temporal_duration: {
+        xpaths: ['.//gmd:EX_Extent[@id="temporalExtent"]'],
+        multivalue: false,
+        reduce: Helpers::SolrFormat::REDUCE_TEMPORAL_DURATION,
+        format: Helpers::R2RFormat::TEMPORAL_DURATION
+      },
+      temporal: {
+        xpaths: ['.//gmd:EX_Extent[@id="temporalExtent"]'],
+        multivalue: false,
+        format:  Helpers::R2RFormat::TEMPORAL_INDEX_STRING
+      },
+      sensors: {
+        xpaths: ['.//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/gmi:MI_Instrument/gmi:type/gmx:Anchor'],
+        multivalue: true
+      },
+      source: {
+        xpaths: [''],
+        default_values: ['ADE'],
+        multivalue: false
+      },
+      facet_data_center: {
+        xpaths: [''],
+        default_values: ["#{Helpers::SolrFormat::DATA_CENTER_NAMES[:R2R][:long_name]} | #{Helpers::SolrFormat::DATA_CENTER_NAMES[:R2R][:short_name]}"],
+        multivalue: false
+      },
+      facet_spatial_scope: {
+        xpaths: ['.//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox'],
+        multivalue: true,
+        format: Helpers::IsoToSolrFormat::FACET_SPATIAL_SCOPE
+      },
+      facet_temporal_duration: {
+        xpaths: ['.//gmd:EX_Extent[@id="temporalExtent"]'],
+        default_values: [Helpers::SolrFormat::NOT_SPECIFIED],
+        format: Helpers::R2RFormat::FACET_TEMPORAL_DURATION,
+        multivalue: true
+      }
+    }
+  end
+end

--- a/lib/search_solr_tools/version.rb
+++ b/lib/search_solr_tools/version.rb
@@ -1,3 +1,3 @@
 module SearchSolrTools
-  VERSION = '3.1.3.pre1'
+  VERSION = '3.1.3.pre2'
 end

--- a/lib/search_solr_tools/version.rb
+++ b/lib/search_solr_tools/version.rb
@@ -1,3 +1,3 @@
 module SearchSolrTools
-  VERSION = '3.1.3.pre2'
+  VERSION = '3.2.0.pre1'
 end

--- a/lib/search_solr_tools/version.rb
+++ b/lib/search_solr_tools/version.rb
@@ -1,3 +1,3 @@
 module SearchSolrTools
-  VERSION = '3.2.0.pre1'
+  VERSION = '3.2.0.pre3'
 end

--- a/spec/unit/fixtures/r2r.xml
+++ b/spec/unit/fixtures/r2r.xml
@@ -1,0 +1,578 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gmi:MI_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmi http://ngdc.noaa.gov/metadata/published/xsd/schema.xsd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:srv="http://www.isotc211.org/2005/srv">
+  <!--NOAA National Data Centers/Rolling Deck to Repository (R2R) ISO Cruise-Level Metadata Template-->
+  <!--Version date: March 23, 2011-->
+  <!--Contact: Anna.Milan@noaa.gov-->
+  <!--http://www.ngdc.noaa.gov/mgg/ecs/metadata/cruise/-->
+  <gmd:fileIdentifier>
+    <gco:CharacterString>AE1319</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gco:CharacterString>eng</gco:CharacterString>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="fieldSession">fieldSession</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:hierarchyLevelName>
+    <gco:CharacterString>cruise level metadata</gco:CharacterString>
+  </gmd:hierarchyLevelName>
+  <gmd:contact>
+    <gmd:CI_ResponsibleParty>
+      <gmd:individualName>
+        <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/person/100001" xlink:actuate="onRequest">R2R Manager</gmx:Anchor>
+      </gmd:individualName>
+      <gmd:organisationName>
+        <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/organization/us.rvdata" xlink:actuate="onRequest">Rolling Deck to Repository (R2R) Program</gmx:Anchor>
+      </gmd:organisationName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:address>
+            <gmd:CI_Address>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>info@rvdata.us</gco:CharacterString>
+              </gmd:electronicMailAddress>
+            </gmd:CI_Address>
+          </gmd:address>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+      </gmd:role>
+    </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:DateTime>2015-06-28T03:11:52Z</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115-2 Geographic Information - Metadata Part 2 Extensions for imagery and gridded data</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>ISO 19115-2:2009(E)</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/cruise/AE1319" xlink:actuate="onRequest">AE1319</gmx:Anchor>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:DateTime>2015-06-28T03:11:52Z</gco:DateTime>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:identifier>
+            <gmd:MD_Identifier>
+              <gmd:code>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/cruise/AE1319" xlink:actuate="onRequest">AE1319</gmx:Anchor>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmd:identifier>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>Biological Controls on the Ocean's C:N:P Ratio</gco:CharacterString>
+      </gmd:abstract>
+      <gmd:purpose>
+        <gco:CharacterString>Biological Controls on the Ocean's C:N:P Ratio</gco:CharacterString>
+      </gmd:purpose>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing">onGoing</gmd:MD_ProgressCode>
+      </gmd:status>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:individualName>
+            <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/person/100351" xlink:actuate="onRequest">Lomas, Michael</gmx:Anchor>
+          </gmd:individualName>
+          <gmd:organisationName>
+            <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/organization/org.bigelow" xlink:actuate="onRequest">Bigelow Laboratory for Ocean Sciences</gmx:Anchor>
+          </gmd:organisationName>
+          <gmd:positionName>
+            <gmx:Anchor xlink:href="http://voc.rvdata.us/role/100002" xlink:actuate="onRequest">Scientist, Chief</gmx:Anchor>
+          </gmd:positionName>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="contributor">contributor</gmd:CI_RoleCode>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>EARTH SCIENCE &gt; Oceans</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme">theme</gmd:MD_KeywordTypeCode>
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>NASA/GCMD Science Keywords</gco:CharacterString>
+              </gmd:title>
+              <gmd:date/>
+              <gmd:citedResponsibleParty>
+                <gmd:CI_ResponsibleParty>
+                  <gmd:organisationName>
+                    <gco:CharacterString>NASA Global Change Master Directory (GCMD) User Support Office</gco:CharacterString>
+                  </gmd:organisationName>
+                  <gmd:contactInfo/>
+                  <gmd:role>
+                    <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+                  </gmd:role>
+                </gmd:CI_ResponsibleParty>
+              </gmd:citedResponsibleParty>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints>
+          <gmd:useLimitation>
+            <gco:CharacterString>Data are not to be used for navigation.</gco:CharacterString>
+          </gmd:useLimitation>
+        </gmd:MD_Constraints>
+      </gmd:resourceConstraints>
+      <gmd:language>
+        <gco:CharacterString>eng</gco:CharacterString>
+      </gmd:language>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>oceans</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>geoscientificInformation</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent id="boundingExtent">
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox id="boundingGeographicBoundingBox">
+              <gmd:westBoundLongitude>
+                <gco:Decimal>-70.24632</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>-39.98639</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>31.63968</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>55.00906</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:extent>
+        <gmd:EX_Extent id="cruiseCoordinates">
+          <gmd:description>
+            <gco:CharacterString>coordinates of ship track</gco:CharacterString>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:polygon><gml:MultiCurve gml:id="segid_1" srsName="EPSG:4326"><gml:curveMember><gml:Curve gml:id="track_1"><gml:segments><gml:LineStringSegment><gml:posList srsDimension="2">-64.6585 32.37952 -64.68182 32.37832 -64.62989 32.37889 -64.61003 32.3647 -64.16727 31.66684 -64.1969 31.70789 -64.31344 32.11482 -64.43391 32.42067 -64.6624 32.88173 -65.00591 33.68543 -65.14102 33.94832 -65.31959 34.3702 -65.5279 34.92214 -66.09715 36.14471 -66.22688 36.54595 -66.30929 36.65658 -66.34509 36.73394 -66.54293 37.34804 -66.64986 37.73413 -66.68159 37.74092 -66.79162 37.87299 -66.92097 38.10114 -67.00066 38.3381 -67.08463 38.75369 -67.37159 39.2181 -67.62526 39.58364 -67.80357 39.90607 -67.9677 40.16232 -68.27736 40.51597 -68.42065 40.7254 -68.67627 41.16857 -68.73165 41.30615 -69.03666 41.79969 -69.07415 41.82417 -69.20425 42.02538 -69.22521 42.03351 -69.44345 42.44624 -69.6186 42.70537 -69.67387 42.71977 -69.72292 42.79518 -69.93017 43.22067 -70.03201 43.47887 -70.15779 43.57992 -70.22406 43.65561 -70.24626 43.65593 -70.22715 43.65722 -70.20547 43.62804 -70.14543 43.61896 -69.77389 43.67311 -69.65523 43.72647 -69.62025 43.80591 -69.6362 43.85081 -69.62043 43.81165 -69.62835 43.72192 -69.54058 43.69702 -69.29859 43.68408 -68.98348 43.60873 -68.3052 43.51018 -67.6375 43.3928 -66.79646 43.36219 -66.56527 43.26678 -66.0504 43.15746 -65.68528 43.13526 -65.28958 43.20847 -65.16003 43.21245 -64.21605 43.45952 -63.55441 43.65312 -63.03734 43.82981 -62.70865 43.8563 -62.22406 43.96487 -61.12793 44.26646 -59.36748 44.67246 -58.32367 45.01399 -54.85433 45.95289 -54.22249 46.16873 -53.96601 46.23622 -53.03192 46.41783 -52.73306 46.49473 -52.4202 47.23143 -52.23719 47.71625 -51.79094 48.75427 -51.52752 49.42431 -51.11832 50.33192 -50.89482 50.90208 -50.47169 51.81412 -50.40391 52.01929 -50.02329 52.87545 -49.84971 53.17104 -49.69426 53.54633 -49.54692 53.83498 -49.13926 54.73439 -48.99907 55.001 -48.9882 54.99446 -49.00797 54.99999 -48.99057 54.99708 -48.99601 55.00899 -49.00859 54.9825 -49.00017 55.00207 -48.86671 54.91358 -48.87872 54.93112 -47.82274 54.23866 -45.99983 52.99842 -46.03603 52.99825 -45.98857 52.99105 -46.02548 53.0181 -45.99568 53.00551 -45.0278 52.40496 -44.25587 51.89261 -43.61944 51.42416 -42.99381 51.00448 -43.00789 50.9978 -42.7809 50.8562 -42.76407 50.87546 -42.74361 50.86668 -42.40996 50.6231 -42.02281 50.3841 -41.57094 50.07862 -41.42544 49.95336 -41.46326 49.91855 -41.45149 49.90468 -40.77537 49.47259 -40.69555 49.40639 -40.62994 49.17876 -40.37439 49.20436 -40.36412 49.08283 -40.0187 49.04209 -39.99315 48.98911 -40.01213 48.9552 -39.98682 49.01151 -40.0846 48.95951 -40.53529 48.60559 -41.255 47.99195 -42.01387 47.40677 -42.49514 47.00373 -42.43243 47.04645 -42.50196 46.99921 -42.49981 47.0118 -42.49878 46.99675 -42.50226 47.01365 -43.17939 46.47101 -43.52138 46.16962 -43.95683 45.81666 -44.82613 45.15984 -44.96785 45.02585 -45.00048 45.03242 -45.00039 44.9931 -45.05532 44.95338 -45.20601 44.7657 -45.42511 44.61449 -45.70113 44.46522 -46.0576 44.20618 -46.20178 44.12145 -46.18677 44.07921 -46.1959 44.06611 -46.41461 43.91742 -46.77377 43.61882 -46.82164 43.59925 -46.95795 43.48778 -47.01169 43.22207 -47.45841 43.02506 -47.48524 42.99885 -47.50952 43.01676 -47.48004 42.99377 -47.50164 42.99932 -48.45492 42.26852 -48.78702 41.98908 -48.97257 41.79971 -49.26824 41.57238 -49.35338 41.48675 -49.89994 41.0904 -50.00135 41.00649 -49.99015 40.99963 -50.0142 40.99727 -50.4916 40.62677 -50.7991 40.36235 -51.69965 39.6649 -52.1074 39.31217 -52.50417 38.99961 -52.48882 38.99668 -53.28171 38.38569 -54.07305 37.7416 -54.36487 37.52598 -54.80891 37.13461 -55.00747 37.00207 -56.32847 35.93569 -56.76771 35.59947 -57.31471 35.14263 -57.52296 34.99415 -57.49516 34.99871 -57.76987 34.76453 -58.40506 34.28795 -60.01291 32.99363 -59.9983 32.99321 -60.00153 33.00331 -60.8831 32.71995 -61.44751 32.52655 -62.02238 32.36197 -63.49868 31.89695 -63.57769 31.86942 -63.59951 31.83019 -63.83332 31.76292 -63.84594 31.71616 -64.1734 31.66577 -64.17338 31.68282 -64.17898 31.64276 -64.16487 31.66909 -64.1703 31.65636 -64.16801 31.67747 -64.19353 31.68955 -64.15314 31.66888 -64.17487 31.66859 -64.16674 31.64702 -64.16408 31.67754 -64.17215 31.64221 -64.19251 31.67695 -64.17352 31.70641 -64.15468 31.70581 -64.1798 31.66714 -64.18076 31.65404 -64.16642 31.68739 -64.16439 31.64493 -64.18087 31.68336 -64.15644 31.65983 -64.15869 31.64633 -64.17856 31.67728 -64.17145 31.63972 -64.18498 31.64523 -64.17657 31.69119 -64.18315 31.64535 -64.2103 31.68612 -64.1796 31.65944 -64.16932 31.67993 -64.33705 32.01436 -64.55608 32.34045 -64.48627 32.32923 -64.54713 32.36787 -64.51721 32.3295 -64.67818 32.39972 -64.72526 32.36463 -64.69586 32.36972</gml:posList></gml:LineStringSegment></gml:segments></gml:Curve></gml:curveMember></gml:MultiCurve></gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:extent>
+        <gmd:EX_Extent id="temporalExtent">
+          <gmd:description>
+            <gco:CharacterString>Cruise Start and End</gco:CharacterString>
+          </gmd:description>
+          <gmd:temporalElement>
+            <gmd:EX_SpatialTemporalExtent>
+              <gmd:extent>
+                <gml:TimeInstant gml:id="start">
+                  <gml:timePosition>2013-08-14</gml:timePosition>
+                </gml:TimeInstant>
+              </gmd:extent>
+              <gmd:spatialExtent>
+                <gmd:EX_GeographicDescription>
+                  <gmd:geographicIdentifier>
+                    <gmd:MD_Identifier>
+                      <gmd:authority>
+                        <gmd:CI_Citation>
+                          <gmd:title>
+                            <gco:CharacterString>University-National Oceanographic Laboratory System (UNOLS) Port Code List</gco:CharacterString>
+                          </gmd:title>
+                          <gmd:date/>
+                        </gmd:CI_Citation>
+                      </gmd:authority>
+                      <gmd:code>
+                        <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/port/100061" xlink:actuate="onRequest">St. George's</gmx:Anchor>
+                      </gmd:code>
+                    </gmd:MD_Identifier>
+                  </gmd:geographicIdentifier>
+                </gmd:EX_GeographicDescription>
+              </gmd:spatialExtent>
+            </gmd:EX_SpatialTemporalExtent>
+          </gmd:temporalElement>
+          <gmd:temporalElement>
+            <gmd:EX_SpatialTemporalExtent>
+              <gmd:extent>
+                <gml:TimeInstant gml:id="end">
+                  <gml:timePosition>2013-09-11</gml:timePosition>
+                </gml:TimeInstant>
+              </gmd:extent>
+              <gmd:spatialExtent>
+                <gmd:EX_GeographicDescription>
+                  <gmd:geographicIdentifier>
+                    <gmd:MD_Identifier>
+                      <gmd:authority>
+                        <gmd:CI_Citation>
+                          <gmd:title>
+                            <gco:CharacterString>University-National Oceanographic Laboratory System (UNOLS) Port Code List</gco:CharacterString>
+                          </gmd:title>
+                          <gmd:date/>
+                        </gmd:CI_Citation>
+                      </gmd:authority>
+                      <gmd:code>
+                        <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/port/100061" xlink:actuate="onRequest">St. George's</gmx:Anchor>
+                      </gmd:code>
+                    </gmd:MD_Identifier>
+                  </gmd:geographicIdentifier>
+                </gmd:EX_GeographicDescription>
+              </gmd:spatialExtent>
+            </gmd:EX_SpatialTemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="collectionSession">collectionSession</gmd:MD_ScopeCode>
+          </gmd:level>
+          <gmd:levelDescription>
+            <gmd:MD_ScopeDescription>
+              <gmd:other>
+                <gco:CharacterString>Descriptions of datasets collected by devices.</gco:CharacterString>
+              </gmd:other>
+            </gmd:MD_ScopeDescription>
+          </gmd:levelDescription>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:source>
+            <gmi:LE_Source>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100001" xlink:actuate="onRequest">RDI OS-75</gmx:Anchor>
+              </gmd:description>
+              <gmd:sourceStep>
+                <gmi:LE_ProcessStep>
+                  <gmd:description>
+                    <gco:CharacterString>Data was collected from this device.</gco:CharacterString>
+                  </gmd:description>
+                  <gmi:output>
+                    <gmi:LE_Source>
+                      <gmd:description>
+                        <gmx:Anchor xlink:href="http://voc.rvdata.us/device/adcp" xlink:actuate="onRequest">adcp</gmx:Anchor>
+                      </gmd:description>
+                      <gmi:processedLevel>
+                        <gmd:MD_Identifier>
+                          <gmd:code>
+                            <gmx:Anchor xlink:href="http://voc.rvdata.us/processing/1" xlink:actuate="onRequest">raw</gmx:Anchor>
+                          </gmd:code>
+                        </gmd:MD_Identifier>
+                      </gmi:processedLevel>
+                    </gmi:LE_Source>
+                  </gmi:output>
+                </gmi:LE_ProcessStep>
+              </gmd:sourceStep>
+            </gmi:LE_Source>
+          </gmd:source>
+          <gmd:source>
+            <gmi:LE_Source>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100002" xlink:actuate="onRequest">Sea-Bird SBE-911plus</gmx:Anchor>
+              </gmd:description>
+              <gmd:sourceStep>
+                <gmi:LE_ProcessStep>
+                  <gmd:description>
+                    <gco:CharacterString>Data was collected from this device.</gco:CharacterString>
+                  </gmd:description>
+                  <gmi:output>
+                    <gmi:LE_Source>
+                      <gmd:description>
+                        <gmx:Anchor xlink:href="http://voc.rvdata.us/device/ctd" xlink:actuate="onRequest">ctd</gmx:Anchor>
+                      </gmd:description>
+                      <gmi:processedLevel>
+                        <gmd:MD_Identifier>
+                          <gmd:code>
+                            <gmx:Anchor xlink:href="http://voc.rvdata.us/processing/1" xlink:actuate="onRequest">raw</gmx:Anchor>
+                          </gmd:code>
+                        </gmd:MD_Identifier>
+                      </gmi:processedLevel>
+                    </gmi:LE_Source>
+                  </gmi:output>
+                </gmi:LE_ProcessStep>
+              </gmd:sourceStep>
+            </gmi:LE_Source>
+          </gmd:source>
+          <gmd:source>
+            <gmi:LE_Source>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100004" xlink:actuate="onRequest">Turner 10-AU</gmx:Anchor>
+              </gmd:description>
+              <gmd:sourceStep>
+                <gmi:LE_ProcessStep>
+                  <gmd:description>
+                    <gco:CharacterString>Data was collected from this device.</gco:CharacterString>
+                  </gmd:description>
+                  <gmi:output>
+                    <gmi:LE_Source>
+                      <gmd:description>
+                        <gmx:Anchor xlink:href="http://voc.rvdata.us/device/fluorometer" xlink:actuate="onRequest">fluorometer</gmx:Anchor>
+                      </gmd:description>
+                      <gmi:processedLevel>
+                        <gmd:MD_Identifier>
+                          <gmd:code>
+                            <gmx:Anchor xlink:href="http://voc.rvdata.us/processing/1" xlink:actuate="onRequest">raw</gmx:Anchor>
+                          </gmd:code>
+                        </gmd:MD_Identifier>
+                      </gmi:processedLevel>
+                    </gmi:LE_Source>
+                  </gmi:output>
+                </gmi:LE_ProcessStep>
+              </gmd:sourceStep>
+            </gmi:LE_Source>
+          </gmd:source>
+          <gmd:source>
+            <gmi:LE_Source>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100006" xlink:actuate="onRequest">Furuno GP-90</gmx:Anchor>
+              </gmd:description>
+              <gmd:sourceStep>
+                <gmi:LE_ProcessStep>
+                  <gmd:description>
+                    <gco:CharacterString>Data was collected from this device.</gco:CharacterString>
+                  </gmd:description>
+                  <gmi:output>
+                    <gmi:LE_Source>
+                      <gmd:description>
+                        <gmx:Anchor xlink:href="http://voc.rvdata.us/device/gnss" xlink:actuate="onRequest">gnss</gmx:Anchor>
+                      </gmd:description>
+                      <gmi:processedLevel>
+                        <gmd:MD_Identifier>
+                          <gmd:code>
+                            <gmx:Anchor xlink:href="http://voc.rvdata.us/processing/1" xlink:actuate="onRequest">raw</gmx:Anchor>
+                          </gmd:code>
+                        </gmd:MD_Identifier>
+                      </gmi:processedLevel>
+                    </gmi:LE_Source>
+                  </gmi:output>
+                </gmi:LE_ProcessStep>
+              </gmd:sourceStep>
+            </gmi:LE_Source>
+          </gmd:source>
+          <gmd:source>
+            <gmi:LE_Source>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100012" xlink:actuate="onRequest">Knudsen 3260</gmx:Anchor>
+              </gmd:description>
+              <gmd:sourceStep>
+                <gmi:LE_ProcessStep>
+                  <gmd:description>
+                    <gco:CharacterString>Data was collected from this device.</gco:CharacterString>
+                  </gmd:description>
+                  <gmi:output>
+                    <gmi:LE_Source>
+                      <gmd:description>
+                        <gmx:Anchor xlink:href="http://voc.rvdata.us/device/singlebeam" xlink:actuate="onRequest">singlebeam</gmx:Anchor>
+                      </gmd:description>
+                      <gmi:processedLevel>
+                        <gmd:MD_Identifier>
+                          <gmd:code>
+                            <gmx:Anchor xlink:href="http://voc.rvdata.us/processing/1" xlink:actuate="onRequest">raw</gmx:Anchor>
+                          </gmd:code>
+                        </gmd:MD_Identifier>
+                      </gmi:processedLevel>
+                    </gmi:LE_Source>
+                  </gmi:output>
+                </gmi:LE_ProcessStep>
+              </gmd:sourceStep>
+            </gmi:LE_Source>
+          </gmd:source>
+          <gmd:source>
+            <gmi:LE_Source>
+              <gmd:description>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100014" xlink:actuate="onRequest">Markey DUSH-5</gmx:Anchor>
+              </gmd:description>
+              <gmd:sourceStep>
+                <gmi:LE_ProcessStep>
+                  <gmd:description>
+                    <gco:CharacterString>Data was collected from this device.</gco:CharacterString>
+                  </gmd:description>
+                  <gmi:output>
+                    <gmi:LE_Source>
+                      <gmd:description>
+                        <gmx:Anchor xlink:href="http://voc.rvdata.us/device/winch" xlink:actuate="onRequest">winch</gmx:Anchor>
+                      </gmd:description>
+                      <gmi:processedLevel>
+                        <gmd:MD_Identifier>
+                          <gmd:code>
+                            <gmx:Anchor xlink:href="http://voc.rvdata.us/processing/1" xlink:actuate="onRequest">raw</gmx:Anchor>
+                          </gmd:code>
+                        </gmd:MD_Identifier>
+                      </gmi:processedLevel>
+                    </gmi:LE_Source>
+                  </gmi:output>
+                </gmi:LE_ProcessStep>
+              </gmd:sourceStep>
+            </gmi:LE_Source>
+          </gmd:source>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+  <gmi:acquisitionInformation>
+    <gmi:MI_AcquisitionInformation>
+      <gmi:platform>
+        <gmi:MI_Platform>
+          <gmi:identifier>
+            <gmd:MD_Identifier>
+              <gmd:authority>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>International Council for the Exploration of the Sea (ICES) Platform Code List</gco:CharacterString>
+                  </gmd:title>
+                  <gmd:date/>
+                  <gmd:citedResponsibleParty/>
+                </gmd:CI_Citation>
+              </gmd:authority>
+              <gmd:code>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/vessel/33H4" xlink:actuate="onRequest">Atlantic Explorer</gmx:Anchor>
+              </gmd:code>
+            </gmd:MD_Identifier>
+          </gmi:identifier>
+          <gmi:description>
+            <gco:CharacterString>SHIP &gt; Atlantic Explorer</gco:CharacterString>
+          </gmi:description>
+          <gmi:sponsor>
+            <gmd:CI_ResponsibleParty>
+              <gmd:organisationName>
+                <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/organization/edu.bios" xlink:actuate="onRequest">Bermuda Institute of Ocean Sciences</gmx:Anchor>
+              </gmd:organisationName>
+              <gmd:contactInfo/>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="operator">operator</gmd:CI_RoleCode>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmi:sponsor>
+          <gmi:instrument>
+            <gmi:MI_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100001" xlink:actuate="onRequest">RDI OS-75</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+              <gmi:type>
+                <gmx:Anchor xlink:href="http://voc.rvdata.us/device/adcp" xlink:actuate="onRequest">adcp</gmx:Anchor>
+              </gmi:type>
+              <gmi:description>
+                <gco:CharacterString>(acoustic doppler current profiler) sonar measures water current velocities</gco:CharacterString>
+              </gmi:description>
+            </gmi:MI_Instrument>
+          </gmi:instrument>
+          <gmi:instrument>
+            <gmi:MI_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100002" xlink:actuate="onRequest">Sea-Bird SBE-911plus</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+              <gmi:type>
+                <gmx:Anchor xlink:href="http://voc.rvdata.us/device/ctd" xlink:actuate="onRequest">ctd</gmx:Anchor>
+              </gmi:type>
+              <gmi:description>
+                <gco:CharacterString>integrated hydro system measures conductivity, temp, pressure, etc.</gco:CharacterString>
+              </gmi:description>
+            </gmi:MI_Instrument>
+          </gmi:instrument>
+          <gmi:instrument>
+            <gmi:MI_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100004" xlink:actuate="onRequest">Turner 10-AU</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+              <gmi:type>
+                <gmx:Anchor xlink:href="http://voc.rvdata.us/device/fluorometer" xlink:actuate="onRequest">fluorometer</gmx:Anchor>
+              </gmi:type>
+              <gmi:description>
+                <gco:CharacterString>measures fluorescence (usually for phytoplankton)</gco:CharacterString>
+              </gmi:description>
+            </gmi:MI_Instrument>
+          </gmi:instrument>
+          <gmi:instrument>
+            <gmi:MI_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100006" xlink:actuate="onRequest">Furuno GP-90</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+              <gmi:type>
+                <gmx:Anchor xlink:href="http://voc.rvdata.us/device/gnss" xlink:actuate="onRequest">gnss</gmx:Anchor>
+              </gmi:type>
+              <gmi:description>
+                <gco:CharacterString>(global navigation satellite system) - GPS/WAAS, GLONASS, Galileo, etc.</gco:CharacterString>
+              </gmi:description>
+            </gmi:MI_Instrument>
+          </gmi:instrument>
+          <gmi:instrument>
+            <gmi:MI_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100012" xlink:actuate="onRequest">Knudsen 3260</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+              <gmi:type>
+                <gmx:Anchor xlink:href="http://voc.rvdata.us/device/singlebeam" xlink:actuate="onRequest">singlebeam</gmx:Anchor>
+              </gmi:type>
+              <gmi:description>
+                <gco:CharacterString>single, dual, or split beam echosounder (profiling sonar); may be either fixed frequency or chirped</gco:CharacterString>
+              </gmi:description>
+            </gmi:MI_Instrument>
+          </gmi:instrument>
+          <gmi:instrument>
+            <gmi:MI_Instrument>
+              <gmi:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="http://linked.rvdata.us/resource/device/100014" xlink:actuate="onRequest">Markey DUSH-5</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmi:identifier>
+              <gmi:type>
+                <gmx:Anchor xlink:href="http://voc.rvdata.us/device/winch" xlink:actuate="onRequest">winch</gmx:Anchor>
+              </gmi:type>
+              <gmi:description>
+                <gco:CharacterString>measures wire tension, speed, payout, etc.</gco:CharacterString>
+              </gmi:description>
+            </gmi:MI_Instrument>
+          </gmi:instrument>
+        </gmi:MI_Platform>
+      </gmi:platform>
+    </gmi:MI_AcquisitionInformation>
+  </gmi:acquisitionInformation>
+</gmi:MI_Metadata>

--- a/spec/unit/harvesters/r2r_spec.rb
+++ b/spec/unit/harvesters/r2r_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe SearchSolrTools::Harvesters::R2R do
+  before(:each) do
+    @harvester = described_class.new(:dev)
+  end
+  describe '#initialize' do
+    it 'has a @data_centers instance variable' do
+      expect(@harvester.instance_variable_defined?(:@data_centers)).to eql true
+      expect(@harvester.instance_variable_get(:@data_centers)).to eql 'Rolling Deck to Repository'
+    end
+
+    it 'has a @translator instance variable' do
+      expect(@harvester.instance_variable_defined?(:@translator)).to eql true
+    end
+
+    it 'has a @metadata_url instance variable' do
+      expect(@harvester.instance_variable_defined?(:@metadata_url)).to eql true
+      expect(@harvester.instance_variable_get(:@metadata_url)).to eql 'http://get.rvdata.us/services/cruise/'
+    end
+  end
+end

--- a/spec/unit/selectors/r2r_spec.rb
+++ b/spec/unit/selectors/r2r_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe SearchSolrTools::Selectors::R2R do
+  fixture = Nokogiri.XML File.open('spec/unit/fixtures/r2r.xml')
+  iso_to_solr = SearchSolrTools::Helpers::IsoToSolr.new(:r2r)
+  solr_doc = iso_to_solr.translate fixture
+
+  test_expectations = [
+    {
+      title: 'should grab the correct authoritative id',
+      xpath: "/doc/field[@name='authoritative_id']",
+      expected_text: 'AE1319'
+    },
+    {
+      title: 'should grab the correct title',
+      xpath: "/doc/field[@name='title']",
+      expected_text: 'AE1319'
+    },
+    {
+      title: 'should grab the correct summary',
+      xpath: "/doc/field[@name='summary']",
+      expected_text: "Biological Controls on the Ocean's C:N:P Ratio"
+    },
+    {
+      title: 'should grab the correct data_centers',
+      xpath: "/doc/field[@name='data_centers']",
+      expected_text: 'Rolling Deck to Repository'
+    },
+    {
+      title: 'should include the correct keywords',
+      xpath: "/doc/field[@name='keywords'][1]",
+      expected_text: 'EARTH SCIENCE > Oceans'
+    },
+    {
+      title: 'should grab the correct dataset_url link',
+      xpath: "/doc/field[@name='dataset_url']",
+      expected_text: 'http://linked.rvdata.us/resource/cruise/AE1319'
+    },
+    {
+      title: 'should grab the correct updated date',
+      xpath: "/doc/field[@name='last_revision_date']",
+      expected_text: '2015-06-28T03:11:52Z'
+    },
+    {
+      title: 'should grab the correct spatial display bounds',
+      xpath: "/doc/field[@name='spatial_coverages'][1]",
+      expected_text: '31.63968 -70.24632 55.00906 -39.98639'
+    },
+    {
+      title: 'should grab the correct spatial bounds',
+      xpath: "/doc/field[@name='spatial'][1]",
+      expected_text: '-70.24632 31.63968 -39.98639 55.00906'
+    },
+    {
+      title: 'should calculate the correct spatial area',
+      xpath: "/doc/field[@name='spatial_area']",
+      expected_text: '23.36938'
+    },
+    {
+      title: 'should grab the correct temporal coverage',
+      xpath: "/doc/field[@name='temporal_coverages'][1]",
+      expected_text: '2013-08-14,2013-09-11'
+    },
+    {
+      title: 'should grab the correct temporal duration',
+      xpath: "/doc/field[@name='temporal_duration']",
+      expected_text: '29'
+    },
+    {
+      title: 'should grab the correct temporal range',
+      xpath: "/doc/field[@name='temporal'][1]",
+      expected_text: '20.130814 20.130911'
+    },
+    {
+      title: 'should grab the correct source',
+      xpath: "/doc/field[@name='source']",
+      expected_text: 'ADE'
+    },
+    {
+      title: 'should grab the correct spatial scope facet',
+      xpath: "/doc/field[@name='facet_spatial_scope'][1]",
+      expected_text: 'Between 1 and 170 degrees of latitude change | Regional'
+    },
+    {
+      title: 'should grab the correct facet_temporal_duration',
+      xpath: "/doc/field[@name='facet_temporal_duration'][1]",
+      expected_text: '< 1 year'
+    }
+  ]
+
+  test_expectations.each do |expectation|
+    it expectation[:title] do
+      expect(solr_doc.xpath(expectation[:xpath]).text.strip).to eql expectation[:expected_text]
+    end
+  end
+end


### PR DESCRIPTION
Unrelated, add `-v` and `--version` subcommands to quickly check the version.

`SearchSolrTools::Harvesters::R2R#harvest` could use some refactoring (and having rubocop enabled) but work on ADE is technically supposed to be done today; not sure how we should proceed with that (perhaps creating a new Issue to make the presence of tech debt clear?).

A couple prereleases were created and published to RubyGems as that is the most convenient way to test the a harvester on QA.

[Pivotal Story](https://www.pivotaltracker.com/story/show/91455338)