### PR TITLE
Fix endless retry bug for OAI feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ Gemfile.lock
 /vendor/bundle
 *.gem
 
+results.html
 results.xml

--- a/bin/search_solr_tools
+++ b/bin/search_solr_tools
@@ -52,7 +52,7 @@ class SolrHarvestCLI < Thor
   desc 'delete_by_data_center', 'Force deletion of documents for a specific data center with timestamps before the passed timestamp in format iso8601 (2014-07-14T21:49:21Z)'
   option :timestamp, required: true
   option :environment, required: true
-  option :data_center,  required: true
+  option :data_center, required: true
   def delete_by_data_center
     harvester = get_harvester_class(options[:data_center]).new options[:environment]
     harvester.delete_old_documents(options[:timestamp],

--- a/lib/search_solr_tools/harvesters/base.rb
+++ b/lib/search_solr_tools/harvesters/base.rb
@@ -129,7 +129,7 @@ module SearchSolrTools
           response = open(request_url, read_timeout: timeout, 'Content-Type' => content_type)
         rescue OpenURI::HTTPError, Timeout::Error, Errno::ETIMEDOUT => e
           retries_left -= 1
-          puts "## REQUEST FAILED ## Retrying #{retries_left} more times..."
+          puts "## REQUEST FAILED ## #{e.class} ## Retrying #{retries_left} more times..."
 
           retry if retries_left > 0
 

--- a/lib/search_solr_tools/harvesters/base.rb
+++ b/lib/search_solr_tools/harvesters/base.rb
@@ -96,7 +96,7 @@ module SearchSolrTools
 
         # Some docs will cause solr to time out during the POST
         begin
-          RestClient.post(url, doc_serialized,  content_type: content_type) do |response, _request, _result|
+          RestClient.post(url, doc_serialized, content_type: content_type) do |response, _request, _result|
             success = response.code == 200
             puts "Error for #{doc_serialized}\n\n response: #{response.body}" unless success
           end

--- a/lib/search_solr_tools/harvesters/base.rb
+++ b/lib/search_solr_tools/harvesters/base.rb
@@ -127,7 +127,7 @@ module SearchSolrTools
         begin
           puts "Request: #{request_url}"
           response = open(request_url, read_timeout: timeout, 'Content-Type' => content_type)
-        rescue OpenURI::HTTPError, Timeout::Error => e
+        rescue OpenURI::HTTPError, Timeout::Error, Errno::ETIMEDOUT => e
           retries_left -= 1
           puts "## REQUEST FAILED ## Retrying #{retries_left} more times..."
 

--- a/lib/search_solr_tools/harvesters/bcodmo.rb
+++ b/lib/search_solr_tools/harvesters/bcodmo.rb
@@ -8,7 +8,7 @@ module SearchSolrTools
       def initialize(env = 'development', die_on_failure = false)
         super env, die_on_failure
         @translator = Translators::BcodmoJsonToSolr.new
-        @wkt_parser = RGeo::WKRep::WKTParser.new(nil, {})   # (factory_generator_=nil,
+        @wkt_parser = RGeo::WKRep::WKTParser.new(nil, {}) # (factory_generator_=nil,
       end
 
       def harvest_and_delete

--- a/lib/search_solr_tools/harvesters/eol.rb
+++ b/lib/search_solr_tools/harvesters/eol.rb
@@ -44,9 +44,7 @@ module SearchSolrTools
       end
 
       def open_xml_document(url)
-        Nokogiri::XML(open(url)) do |config|
-          config.strict
-        end
+        Nokogiri::XML(open(url), &:strict)
       end
     end
   end

--- a/lib/search_solr_tools/harvesters/oai.rb
+++ b/lib/search_solr_tools/harvesters/oai.rb
@@ -27,7 +27,7 @@ module SearchSolrTools
           begin
             insert_solr_docs(translated_docs(results))
           rescue => e
-            puts "ERROR: #{e}"
+            puts "ERROR: #{e.class} #{e}"
             raise e if @die_on_failure
           end
         end

--- a/lib/search_solr_tools/helpers/iso_to_solr.rb
+++ b/lib/search_solr_tools/helpers/iso_to_solr.rb
@@ -87,7 +87,7 @@ module SearchSolrTools
           text.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
         end
 
-        text.gsub!("\u00BF", '') if text.respond_to?(:gsub!)
+        text.delete!("\u00BF") if text.respond_to?(:gsub!)
 
         text
       end

--- a/lib/search_solr_tools/helpers/translate_temporal_coverage.rb
+++ b/lib/search_solr_tools/helpers/translate_temporal_coverage.rb
@@ -25,7 +25,7 @@ module SearchSolrTools
         max_temporal_duration = SolrFormat.reduce_temporal_duration(temporal_durations)
         facet = SolrFormat.get_temporal_duration_facet(max_temporal_duration)
 
-        { 'temporal_coverages' => temporal_display, 'temporal_duration' => max_temporal_duration, 'temporal' => temporal_index_str, 'facet_temporal_duration' => facet  }
+        { 'temporal_coverages' => temporal_display, 'temporal_duration' => max_temporal_duration, 'temporal' => temporal_index_str, 'facet_temporal_duration' => facet }
       end
 
       def self.format_string(value)

--- a/lib/search_solr_tools/selectors/echo_iso.rb
+++ b/lib/search_solr_tools/selectors/echo_iso.rb
@@ -72,7 +72,7 @@ module SearchSolrTools
       temporal_coverages: {
         xpaths: ['.//Collection/Temporal/RangeDateTime'],
         multivalue: true,
-        format:  Helpers::IsoToSolrFormat::TEMPORAL_DISPLAY_STRING_FORMATTED
+        format: Helpers::IsoToSolrFormat::TEMPORAL_DISPLAY_STRING_FORMATTED
       },
       temporal_duration: {
         xpaths: ['.//Collection/Temporal/RangeDateTime'],

--- a/lib/search_solr_tools/selectors/ices_iso.rb
+++ b/lib/search_solr_tools/selectors/ices_iso.rb
@@ -75,7 +75,7 @@ module SearchSolrTools
       temporal: {
         xpaths: ['.//gmd:EX_TemporalExtent'],
         multivalue: true,
-        format:  Helpers::IsoToSolrFormat::TEMPORAL_INDEX_STRING
+        format: Helpers::IsoToSolrFormat::TEMPORAL_INDEX_STRING
       },
       sensors: {
         xpaths: ['.//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/gmi:MI_Instrument/gmi:citation/gmd:CI_Citation/gmd:title/gco:CharacterString'],

--- a/lib/search_solr_tools/selectors/nodc_iso.rb
+++ b/lib/search_solr_tools/selectors/nodc_iso.rb
@@ -75,7 +75,7 @@ module SearchSolrTools
       temporal: {
         xpaths: ['.//gmd:EX_TemporalExtent'],
         multivalue: true,
-        format:  Helpers::IsoToSolrFormat::TEMPORAL_INDEX_STRING
+        format: Helpers::IsoToSolrFormat::TEMPORAL_INDEX_STRING
       },
       sensors: {
         xpaths: ['.//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/gmi:MI_Instrument/gmi:citation/gmd:CI_Citation/gmd:title/gco:CharacterString'],

--- a/lib/search_solr_tools/selectors/r2r.rb
+++ b/lib/search_solr_tools/selectors/r2r.rb
@@ -81,7 +81,7 @@ module SearchSolrTools
       temporal: {
         xpaths: ['.//gmd:EX_Extent[@id="temporalExtent"]'],
         multivalue: false,
-        format:  Helpers::R2RFormat::TEMPORAL_INDEX_STRING
+        format: Helpers::R2RFormat::TEMPORAL_INDEX_STRING
       },
       sensors: {
         xpaths: ['.//gmi:acquisitionInformation/gmi:MI_AcquisitionInformation/gmi:instrument/gmi:MI_Instrument/gmi:type/gmx:Anchor'],

--- a/lib/search_solr_tools/translators/nsidc_json.rb
+++ b/lib/search_solr_tools/translators/nsidc_json.rb
@@ -175,7 +175,7 @@ module SearchSolrTools
       end
 
       def generate_part_array(json, limit_values = nil)
-        parts =  []
+        parts = []
         json = json.select { |k, _v| limit_values.include?(k) } unless limit_values.nil? || limit_values.empty?
 
         json.each do |_k, v|

--- a/spec/unit/harvesters/harvester_base_spec.rb
+++ b/spec/unit/harvesters/harvester_base_spec.rb
@@ -26,6 +26,52 @@ describe SearchSolrTools::Harvesters::Base do
     end
   end
 
+  describe '#get_results' do
+    describe 'with @die_on_failure ' do
+      let(:described_object) { described_class.new('development', true) }
+
+      def described_method(request_url, metadata_path, content_type = 'application/xml')
+        described_object.get_results(request_url, metadata_path, content_type)
+      end
+
+      describe 'with error OpenURI::HTTPError' do
+        before(:each) do
+          exception_io = double('io')
+          exception_io.stub_chain(:status,:[]).with(0).and_return('302')
+
+          allow(described_object).to receive(:open).and_raise(OpenURI::HTTPError.new('',exception_io))
+        end
+
+        it 'makes 3 attempts before propagating the error' do
+          expect(described_object).to receive(:open).exactly(3).times
+          expect do
+            described_method(
+              'http://www.polardata.ca/oai/provider?verb=ListRecords&metadataPrefix=iso',
+              '/metadata/xpath'
+            )
+          end.to raise_error(OpenURI::HTTPError)
+        end
+      end
+
+      [Timeout::Error, Errno::ETIMEDOUT].each do |err_type|
+        describe "with error #{err_type}" do
+          before(:each) do
+            allow(described_object).to receive(:open).and_raise(err_type)
+          end
+
+          it 'makes 3 attempts before propagating the error' do
+            expect(described_object).to receive(:open).exactly(3).times
+            expect do described_method(
+                        'http://www.polardata.ca/oai/provider?verb=ListRecords&metadataPrefix=iso',
+                        '/metadata/xpath'
+                      )
+            end.to raise_error(err_type)
+          end
+        end
+      end
+    end
+  end
+
   it 'Builds a new Nokogiri XML document with an "add" root node' do
     doc = described_class.new.create_new_solr_add_doc
     expect(doc.root.name).to eql('add')

--- a/spec/unit/harvesters/harvester_base_spec.rb
+++ b/spec/unit/harvesters/harvester_base_spec.rb
@@ -59,9 +59,9 @@ describe SearchSolrTools::Harvesters::Base do
       describe 'with error OpenURI::HTTPError' do
         before(:each) do
           exception_io = double('io')
-          exception_io.stub_chain(:status,:[]).with(0).and_return('302')
+          exception_io.stub_chain(:status, :[]).with(0).and_return('302')
 
-          allow(described_object).to receive(:open).and_raise(OpenURI::HTTPError.new('',exception_io))
+          allow(described_object).to receive(:open).and_raise(OpenURI::HTTPError.new('', exception_io))
         end
 
         it 'makes 3 attempts before propagating the error' do
@@ -83,10 +83,11 @@ describe SearchSolrTools::Harvesters::Base do
 
           it 'makes 3 attempts before propagating the error' do
             expect(described_object).to receive(:open).exactly(3).times
-            expect do described_method(
-                        'http://www.polardata.ca/oai/provider?verb=ListRecords&metadataPrefix=iso',
-                        '/metadata/xpath'
-                      )
+            expect do
+              described_method(
+                'http://www.polardata.ca/oai/provider?verb=ListRecords&metadataPrefix=iso',
+                '/metadata/xpath'
+              )
             end.to raise_error(err_type)
           end
         end

--- a/spec/unit/harvesters/harvester_base_spec.rb
+++ b/spec/unit/harvesters/harvester_base_spec.rb
@@ -34,6 +34,28 @@ describe SearchSolrTools::Harvesters::Base do
         described_object.get_results(request_url, metadata_path, content_type)
       end
 
+      describe 'with a successful response' do
+        let(:nokogiri) { double(Nokogiri) }
+        let(:doc) { double('doc') }
+        let(:parsed_metadata) { double('parsed_metadata') }
+
+        before(:each) do
+          response = double('response')
+          allow(described_object).to receive(:open).and_return(response)
+          allow(nokogiri).to receive(:XML).and_return(doc)
+          allow(doc).to receive(:xpath).and_return(parsed_metadata)
+        end
+
+        it 'returns metadata from the XML response' do
+          expect do
+            described_method(
+              'http://www.polardata.ca/oai/provider?verb=ListRecords&metadataPrefix=iso',
+              '/metadata/xpath'
+            ).to eql(parsed_metadata)
+          end
+        end
+      end
+
       describe 'with error OpenURI::HTTPError' do
         before(:each) do
           exception_io = double('io')

--- a/spec/unit/helpers/csw_iso_query_builder_spec.rb
+++ b/spec/unit/helpers/csw_iso_query_builder_spec.rb
@@ -8,7 +8,7 @@ describe SearchSolrTools::Helpers::CswIsoQueryBuilder do
     end
 
     it 'Returns a URL with a result type of "hits"' do
-      query = described_class.get_query_string('http://fakeurl.org/csw',  'resultType' => 'hits')
+      query = described_class.get_query_string('http://fakeurl.org/csw', 'resultType' => 'hits')
       expect(query).to eq 'http://fakeurl.org/csw?service=CSW&version=2.0.2&request=GetRecords&TypeNames=gmd:MD_Metadata&ElementSetName=full&resultType=hits&outputFormat=application/xml&maxRecords=25&startPosition=1&outputSchema=http://www.isotc211.org/2005/gmd'
     end
   end


### PR DESCRIPTION
In [one run of harvesting the PDC feed](https://ops.nsidc.org/jenkins/job/Search-Solr_Harvest/DATA_CENTER=pdc,ENVIRONMENT=production/72/console), the URL was hit 150 times before succeeding. We don't want to just hammer the servers of external feeds when there is a problem, and there is logic already in place to only retry a couple of times; that logic was just missing the exception raised in this particular case.

* add `Errno::ETIMEDOUT` to the list of errors caught in the `begin/rescue/retry` block
* include the error class in the output to help future debugging
* add tests for each error case, and the non-error case, around `SearchSolrTools::Harvesters::Base#get_results`

https://www.pivotaltracker.com/story/show/103057378