### PR TITLE
Fix strange temporal duration facet values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
+## v3.3.1
+
+Bugfix
+
+  - Remove strange facet string for temporal duration from NOAA Paleo search
+    results.
+
 ## v3.3.0
 
 New Features
 
--  Add harvest support for
+  -  Add harvest support for
    [NOAA Paleoclimatology Data Center (NOAA Paleo)](https://www.ncdc.noaa.gov/data-access/paleoclimatology-data/datasets).
 
--  Add harvest support for
-   [Data Observation Network for Earth (Data ONE)](https://www.dataone.org/).
-   [Pivotal 77763710](https://www.pivotaltracker.com/story/show/77763710)
+  -  Add harvest support for
+   [Data Observation Network for Earth (Data ONE)](https://www.dataone.org/). [Pivotal 77763710](https://www.pivotaltracker.com/story/show/77763710)
 
 ## v3.2.1 (2015-09-23)
 

--- a/lib/search_solr_tools/helpers/ncdc_paleo_format.rb
+++ b/lib/search_solr_tools/helpers/ncdc_paleo_format.rb
@@ -47,7 +47,7 @@ module SearchSolrTools
 
       def self.get_temporal_duration(node)
         range = date_range(node)
-        return if range.empty?
+        return if range.to_s.empty?
         (range[:start] - range[:end]).to_i.abs
       end
 


### PR DESCRIPTION
For a few datasets, `date_range` is returning `nil` here. This leads to
an error in calculating the duration for faceting purposes, and the
string describing the duration (and ending up in the interface) is the
original coverage string from the feed instead of "Not specified".

By converting the result of `date_range` to a string before calling
`empty?`, `nil` is return from `get_temporal_duration`, and the facet
duration string ends up as "Not specified".