### PR TITLE
`rake default` - always run rubocop *and* tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,14 @@ Dir.glob('./tasks/*.rake').each { |r| import r }
 RuboCop::RakeTask.new
 
 desc 'Run RuboCop and RSpec code examples'
-task default: %w(rubocop spec:unit)
+task :default do
+  failure = false
+
+  %w(rubocop spec:unit).each do |task_name|
+    sh "rake #{task_name}" do
+      failure = true
+    end
+  end
+
+  exit failure ? 1 : 0
+end


### PR DESCRIPTION
Travis-CI runs the default rake task. In the previous configuration, if
rubocop encountered an error, the unit tests were not run. This hid the
fact that unit tests were actually broken in [build 150][0]. We want to
always run both rubocop and unit tests, so that all build issues are
apparent.

By running each task in its own process, rather than as prerequisites of
the `default` task, we ensure that each task is run, and can choose to
exit a failing status if any of the individual tasks failed (taken from
the [The Rake Field Manual][1]).

[0]: https://travis-ci.org/nsidc/search-solr-tools/builds/90809018
[1]: http://www.rakefieldmanual.com/fascicles/002-ignore-failed-tasks.html