### PR TITLE
Update URL for NSF Arctic Data Center

### DIFF
--- a/lib/search_solr_tools/config/environments.yaml
+++ b/lib/search_solr_tools/config/environments.yaml
@@ -4,7 +4,7 @@
   :collection_path: solr
   :port: 8983
   :bcodmo_url: http://www.bco-dmo.org/nsidc/arctic-deployments.json
-  :adc_url: https://knb.ecoinformatics.org/knb/d1/mn/v2/query/solr/
+  :adc_url: https://arcticdata.io/metacat/d1/mn/v2/query/solr/
   :data_one_url: https://cn.dataone.org/cn/v1/query/solr/select?q=northBoundCoord:%5B45.0%20TO%2090.0%5D
   :echo_url: https://api.echo.nasa.gov/catalog-rest/echo_catalog/datasets.echo10
   :gtnp:

--- a/spec/unit/harvesters/adc_harvester_spec.rb
+++ b/spec/unit/harvesters/adc_harvester_spec.rb
@@ -18,7 +18,7 @@ describe SearchSolrTools::Harvesters::Adc do
 
   describe '#metadata_url' do
     it 'is set to the arctic data center feed URL' do
-      expect(@harvester.metadata_url).to eql 'https://knb.ecoinformatics.org/knb/d1/mn/v2/query/solr/'
+      expect(@harvester.metadata_url).to eql 'https://arcticdata.io/metacat/d1/mn/v2/query/solr/'
     end
   end
 end


### PR DESCRIPTION
The knb.ecoinformatics.org link mentioned in the NSF ADC api page
points to a repo of ecological data.