### PR TITLE
Show the BCO-DMO URL the same way as every other data center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Bugfixes
     failures when there are issues with individual records; we don't want
     harvesting to stop due to a metadata issue with a small number of
     records.
+  - Include BCO-DMO URL in the harvester output the same way all the other URLs
+    are displayed.
 
 ## v3.3.3 (2015-05-10)
 

--- a/lib/search_solr_tools/harvesters/bcodmo.rb
+++ b/lib/search_solr_tools/harvesters/bcodmo.rb
@@ -12,7 +12,12 @@ module SearchSolrTools
       end
 
       def harvest_and_delete
+        puts "Running harvest of BCO-DMO catalog from #{bcodmo_url}"
         super(method(:harvest_bcodmo_into_solr), "data_centers:\"#{Helpers::SolrFormat::DATA_CENTER_NAMES[:BCODMO][:long_name]}\"")
+      end
+
+      def bcodmo_url
+        SolrEnvironments[@environment][:bcodmo_url]
       end
 
       def harvest_bcodmo_into_solr


### PR DESCRIPTION
Turns out BCO-DMO was the only harvester not doing it; the other harvesters all do it in the `harvest_and_delete` method. Note that some of them inherit this method from `oai.rb`.