### PR TITLE
Only fail on BCO-DMO records with --die-on-failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v3.8.1 (2017-03-29)
+
+Bugfix
+
+  - Fix BCO-DMO harvester to only fail when there are issues with individual
+    records if `--die-on-failure` is given.
+
 ## v3.8.0 (2017-03-28)
 
 Changes

--- a/lib/search_solr_tools/harvesters/bcodmo.rb
+++ b/lib/search_solr_tools/harvesters/bcodmo.rb
@@ -22,8 +22,10 @@ module SearchSolrTools
 
       def harvest_bcodmo_into_solr
         result = translate_bcodmo
-        insert_solr_docs result[:add_docs], Base::JSON_CONTENT_TYPE
-        fail 'Failed to harvest some records from the provider' if result[:failure_ids].length > 0
+        insert_solr_docs(result[:add_docs], Base::JSON_CONTENT_TYPE)
+
+        errors_exist = result[:failure_ids].length > 0
+        fail 'Failed to harvest some records from BCO-DMO' if errors_exist && @die_on_failure
       end
 
       def translate_bcodmo


### PR DESCRIPTION
Got errors for some records in Jenkins when harvesting for integration, could not replicate harvesting in dev. This change however will prevent individual records from breaking the harvest job.