### PR TITLE
removing TRAVIS references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: ruby
-before_install:
-- export TZ=America/Denver

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gem Version](https://badge.fury.io/rb/search_solr_tools.svg)](http://badge.fury.io/rb/search_solr_tools) [![Build Status](https://travis-ci.org/nsidc/search-solr-tools.svg?branch=master)](https://travis-ci.org/nsidc/search-solr-tools)
+[![Gem Version](https://badge.fury.io/rb/search_solr_tools.svg)](http://badge.fury.io/rb/search_solr_tools)
 
 # NSIDC Search Solr Tools
 


### PR DESCRIPTION
It looks like the travis stuff is no more, as the build "tag" in README would just say "unknown".  If there's a way to get to it, there's no documentation for it, so I think it would be cleaner just to get rid of the travis-ci stuff outright.