### PR TITLE
SRCH-145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-  - Tidy up deployment tagging in an effort to reduce duplicate action workflows.
+  - Tidy up deployment tagging in an effort to eliminate duplicate action workflows.
 
 ## v7.2.0 (2023-10-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-  - Tidy up deployment tagging.
+  - Tidy up deployment tagging in an effort to reduce duplicate action workflows.
 
 ## v7.2.0 (2023-10-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+  - Tidy up deployment tagging.
+
 ## v7.2.0 (2023-10-19)
 
   - Force parameter facets based on GCMD keywords to be upper-case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-  - Tidy up deployment tagging in an effort to eliminate duplicate action workflows.
+  - Revert deployment tagging changes, since they didn't solve the duplicate
+    workflow trigger problem.
 
 ## v7.2.0 (2023-10-19)
 

--- a/tasks/bump.rake
+++ b/tasks/bump.rake
@@ -28,7 +28,7 @@ def bump_and_push(version_part)
   update_changelog(Bump::Bump.next_version(version_part))
   Bump::Bump.run(version_part, tag: true, commit: true, changelog: false)
 
-  sh %(git push origin HEAD --tags)
+  sh %(git push origin HEAD --tags --atomic)
 end
 
 def version_rb

--- a/tasks/bump.rake
+++ b/tasks/bump.rake
@@ -28,7 +28,7 @@ def bump_and_push(version_part)
   update_changelog(Bump::Bump.next_version(version_part))
   Bump::Bump.run(version_part, tag: true, commit: true, changelog: false)
 
-  sh %(git push origin HEAD --tags --atomic)
+  sh %(git push origin HEAD --tags)
 end
 
 def version_rb

--- a/tasks/bump.rake
+++ b/tasks/bump.rake
@@ -28,7 +28,7 @@ def bump_and_push(version_part)
   update_changelog(Bump::Bump.next_version(version_part))
   Bump::Bump.run(version_part, tag: true, commit: true, changelog: false)
 
-  sh %(git push --atomic)
+  sh %(git push origin HEAD --tags)
 end
 
 def version_rb


### PR DESCRIPTION
Revert/modify changes to the `bump` task which were intended to handle pushing file changes and tags in one step, thus avoiding a double-trigger of CI actions. Unfortunately the changes didn't work, and I haven't found any other syntax that prevents two CI jobs from being triggered when a version is bumped and the branch tagged (one job triggered for the tag, one for the CHANGELOG.md update). It's possible that using annotated tags and `--follow-tags` will accomplish what I'm after, but I don't see support for annotated tags in the `Bump` gem. I will have to live with the double-CI-trigger!